### PR TITLE
Ajout_Chatbot_extension_base.html.twig

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -21,5 +21,21 @@
 
 {% endblock %}
 
+        <!--Start of Tawk.to Script-->
+        <script type="text/javascript">
+        var Tawk_API=Tawk_API||{}
+        var Tawk_LoadStart=new Date();
+        (function(){
+            var s1=document.createElement("script")
+            var s0=document.getElementsByTagName("script")[0];
+            s1.async=true;
+            s1.src='https://embed.tawk.to/6729d6874304e3196add4f38/1ibtms0i6';
+            s1.charset='UTF-8';
+            s1.setAttribute('crossorigin','*');
+            s0.parentNode.insertBefore(s1,s0);
+        })();
+        </script>
+        <!--End of Tawk.to Script-->
+
 </body>
 </html>


### PR DESCRIPTION
Ajout du Chatbot Gecko sur toutes les pages du site basé sur le fichier base.html.twig (qui contient {% extends 'base.html.twig' %})